### PR TITLE
Fixes on stored info (v1.2.2)

### DIFF
--- a/api/src/main/java/AlloyGetInstances.java
+++ b/api/src/main/java/AlloyGetInstances.java
@@ -113,10 +113,10 @@ public class AlloyGetInstances {
 		A4Solution ans = RestApplication.getSol(req.sessionId);
 		int cnt = 0;
 		for (int n = 0; n < req.numberOfInstances && ans.satisfiable(); n++) {
-			ans = RestApplication.getSol(req.sessionId);
 			cnt = RestApplication.getCnt(req.sessionId);
 			solsArrayJSON.add(answerToJson(req.sessionId, ans, warnings, cnt));
 			RestApplication.next(req.sessionId);
+			ans = RestApplication.getSol(req.sessionId);
 		}
 		if (!ans.satisfiable())
 			solsArrayJSON.add(answerToJson(req.sessionId, ans, warnings, cnt));

--- a/api/src/main/java/AlloyGetInstances.java
+++ b/api/src/main/java/AlloyGetInstances.java
@@ -85,7 +85,7 @@ public class AlloyGetInstances {
 			Command command = world.getAllCommands().get(req.commandIndex);
 			try {
 				A4Solution ans = TranslateAlloyToKodkod.execute_command(rep, world.getAllReachableSigs(), command, opt);
-				RestApplication.add(req.sessionId,ans);
+				RestApplication.add(req.sessionId,ans,command.check);
 
 				res = batchAdd(req,warnings);
 
@@ -111,15 +111,16 @@ public class AlloyGetInstances {
 	private String batchAdd(InstancesRequest req,List<ErrorWarning> warnings) {
 		JsonArrayBuilder solsArrayJSON = Json.createArrayBuilder();
 		A4Solution ans = RestApplication.getSol(req.sessionId);
+		boolean type = RestApplication.getType(req.sessionId);
 		int cnt = 0;
 		for (int n = 0; n < req.numberOfInstances && ans.satisfiable(); n++) {
 			cnt = RestApplication.getCnt(req.sessionId);
-			solsArrayJSON.add(answerToJson(req.sessionId, ans, warnings, cnt));
+			solsArrayJSON.add(answerToJson(req.sessionId, ans, warnings, type, cnt));
 			RestApplication.next(req.sessionId);
 			ans = RestApplication.getSol(req.sessionId);
 		}
 		if (!ans.satisfiable())
-			solsArrayJSON.add(answerToJson(req.sessionId, ans, warnings, cnt));
+			solsArrayJSON.add(answerToJson(req.sessionId, ans, warnings, type, cnt));
 		String res = solsArrayJSON.build().toString();
 
 		return res;
@@ -137,7 +138,7 @@ public class AlloyGetInstances {
 		return req;
 	}
 
-	public JsonObject answerToJson(String sessionId, A4Solution answer, List<ErrorWarning> warns, int cnt) {
+	public JsonObject answerToJson(String sessionId, A4Solution answer, List<ErrorWarning> warns, boolean type, int cnt) {
 		JsonObjectBuilder instanceJSON = Json.createObjectBuilder();
 
 		if (warns.size() > 0) {
@@ -149,6 +150,7 @@ public class AlloyGetInstances {
 
 		instanceJSON.add("sessionId", sessionId.toString());
 		instanceJSON.add("unsat", !answer.satisfiable());
+		instanceJSON.add("check", type);
 		instanceJSON.add("cnt", cnt);
 
 		if (answer.satisfiable()) {

--- a/api/src/main/java/AlloyGetInstances.java
+++ b/api/src/main/java/AlloyGetInstances.java
@@ -85,7 +85,7 @@ public class AlloyGetInstances {
 			Command command = world.getAllCommands().get(req.commandIndex);
 			try {
 				A4Solution ans = TranslateAlloyToKodkod.execute_command(rep, world.getAllReachableSigs(), command, opt);
-				RestApplication.add(req.sessionId,ans,command.check);
+				RestApplication.add(req.sessionId,ans,command);
 
 				res = batchAdd(req,warnings);
 
@@ -111,16 +111,16 @@ public class AlloyGetInstances {
 	private String batchAdd(InstancesRequest req,List<ErrorWarning> warnings) {
 		JsonArrayBuilder solsArrayJSON = Json.createArrayBuilder();
 		A4Solution ans = RestApplication.getSol(req.sessionId);
-		boolean type = RestApplication.getType(req.sessionId);
+		Command cmd = RestApplication.getCommand(req.sessionId);
 		int cnt = 0;
 		for (int n = 0; n < req.numberOfInstances && ans.satisfiable(); n++) {
-			cnt = RestApplication.getCnt(req.sessionId);
-			solsArrayJSON.add(answerToJson(req.sessionId, ans, warnings, type, cnt));
+			solsArrayJSON.add(answerToJson(req.sessionId, ans, warnings, cmd, cnt));
 			RestApplication.next(req.sessionId);
 			ans = RestApplication.getSol(req.sessionId);
+			cnt = RestApplication.getCnt(req.sessionId);
 		}
 		if (!ans.satisfiable())
-			solsArrayJSON.add(answerToJson(req.sessionId, ans, warnings, type, cnt));
+			solsArrayJSON.add(answerToJson(req.sessionId, ans, warnings, cmd, cnt));
 		String res = solsArrayJSON.build().toString();
 
 		return res;
@@ -138,7 +138,7 @@ public class AlloyGetInstances {
 		return req;
 	}
 
-	public JsonObject answerToJson(String sessionId, A4Solution answer, List<ErrorWarning> warns, boolean type, int cnt) {
+	public JsonObject answerToJson(String sessionId, A4Solution answer, List<ErrorWarning> warns, Command cmd, int cnt) {
 		JsonObjectBuilder instanceJSON = Json.createObjectBuilder();
 
 		if (warns.size() > 0) {
@@ -150,7 +150,8 @@ public class AlloyGetInstances {
 
 		instanceJSON.add("sessionId", sessionId.toString());
 		instanceJSON.add("unsat", !answer.satisfiable());
-		instanceJSON.add("check", type);
+		instanceJSON.add("check", cmd.check);
+		instanceJSON.add("cmd_n", cmd.label);
 		instanceJSON.add("cnt", cnt);
 
 		if (answer.satisfiable()) {

--- a/api/src/main/java/RestApplication.java
+++ b/api/src/main/java/RestApplication.java
@@ -1,6 +1,7 @@
 import javax.ws.rs.core.Application;
 
 import edu.mit.csail.sdg.translator.A4Solution;
+import edu.mit.csail.sdg.ast.Command;
 
 import java.util.HashMap;
 
@@ -11,18 +12,18 @@ public class RestApplication extends Application {
 	
 	private static HashMap<String, A4Solution> answers = new HashMap<String, A4Solution>();
 	private static HashMap<String, Integer> count = new HashMap<String, Integer>();
-	private static HashMap<String, Boolean> type = new HashMap<String, Boolean>();
+	private static HashMap<String, Command> cmd = new HashMap<String, Command>();
     
 	public static void remove(String str) {
 		answers.remove(str);
 		count.remove(str);
-		type.remove(str);
+		cmd.remove(str);
 	}
 
-	public static void add(String str, A4Solution ans, boolean tp) {
+	public static void add(String str, A4Solution ans, Command cm) {
 		answers.put(str,ans);
 		count.put(str,0);
-		type.put(str,tp);
+		cmd.put(str,cm);
 	}
 
 	public static A4Solution getSol(String str) {
@@ -33,8 +34,8 @@ public class RestApplication extends Application {
 		return count.get(str);
 	}
 
-	public static boolean getType(String str) {
-		return type.get(str);
+	public static Command getCommand(String str) {
+		return cmd.get(str);
 	}
 
 	public static void next(String str) {

--- a/api/src/main/java/RestApplication.java
+++ b/api/src/main/java/RestApplication.java
@@ -11,15 +11,18 @@ public class RestApplication extends Application {
 	
 	private static HashMap<String, A4Solution> answers = new HashMap<String, A4Solution>();
 	private static HashMap<String, Integer> count = new HashMap<String, Integer>();
+	private static HashMap<String, Boolean> type = new HashMap<String, Boolean>();
     
 	public static void remove(String str) {
 		answers.remove(str);
 		count.remove(str);
+		type.remove(str);
 	}
 
-	public static void add(String str, A4Solution ans) {
+	public static void add(String str, A4Solution ans, boolean tp) {
 		answers.put(str,ans);
 		count.put(str,0);
+		type.put(str,tp);
 	}
 
 	public static A4Solution getSol(String str) {
@@ -28,6 +31,10 @@ public class RestApplication extends Application {
 
 	public static int getCnt(String str) {
 		return count.get(str);
+	}
+
+	public static boolean getType(String str) {
+		return type.get(str);
 	}
 
 	public static void next(String str) {

--- a/meteor/client/templates/alloyEditor/alloyEditor.js
+++ b/meteor/client/templates/alloyEditor/alloyEditor.js
@@ -309,7 +309,7 @@ function handleExecuteModel(err, result) {
 }
 
 function storeInstances(allInstances) {
-    if (allInstances[0].cnt == 0) {
+    if (allInstances.alloy_error || allInstances[0].cnt == 0) {
         instances = allInstances;
         instanceIndex = 0;
         maxInstanceNumber = allInstances.length;

--- a/meteor/client/templates/alloyEditor/alloyEditor.js
+++ b/meteor/client/templates/alloyEditor/alloyEditor.js
@@ -88,7 +88,7 @@ Template.alloyEditor.events({
             });
         } else { // Execute command
             let model = textEditor.getValue();
-            Meteor.call('getInstances', model, commandIndex, Session.get("last_id"), handleExecuteModel);
+            Meteor.call('getInstances', model, commandIndex, Session.get("from_private"), Session.get("last_id"), handleExecuteModel);
         }
         // update button states after execution
         $("#exec > button").prop('disabled', true);
@@ -223,6 +223,8 @@ Template.alloyEditor.onRendered(() => {
                 updateElementSelectionContent();
             }
         }
+    } else {
+        Session.set("from_private", true);
     }
     styleRightClickMenu();
     $('#optionsMenu').hide();

--- a/meteor/client/templates/alloyEditor/alloyEditor.js
+++ b/meteor/client/templates/alloyEditor/alloyEditor.js
@@ -119,7 +119,7 @@ Template.alloyEditor.events({
         if (evt.toElement.id != "next") {
             if (instanceIndex == maxInstanceNumber-1) {
                 let model = textEditor.getValue();
-                Meteor.call('nextInstances', model, getCommandIndex(), isRunSelected(), Session.get("last_id"), handleExecuteModel);
+                Meteor.call('nextInstances', model, getCommandIndex(), Session.get("last_id"), handleExecuteModel);
                 //$("#next > button").prop('disabled', true);
             }
             let ni = getNextInstance();

--- a/meteor/client/templates/alloyEditor/alloyEditor.js
+++ b/meteor/client/templates/alloyEditor/alloyEditor.js
@@ -88,7 +88,7 @@ Template.alloyEditor.events({
             });
         } else { // Execute command
             let model = textEditor.getValue();
-            Meteor.call('getInstances', model, commandIndex, isRunSelected(), Session.get("last_id"), handleExecuteModel);
+            Meteor.call('getInstances', model, commandIndex, Session.get("last_id"), handleExecuteModel);
         }
         // update button states after execution
         $("#exec > button").prop('disabled', true);
@@ -280,16 +280,16 @@ function handleExecuteModel(err, result) {
 
             if (result.unsat) {
                 $('#instancenav').hide();
-                paragraph.innerHTML = result.commandType ? "No instance found. " + command + " is inconsistent." : "No counter-examples. " + command + " solved!";
-                paragraph.className = result.commandType ? "log-wrong" : "log-complete";
+                paragraph.innerHTML = result.check ? "No counter-examples. " + command + " solved!" : "No instance found. " + command + " is inconsistent.";
+                paragraph.className = result.check ? "log-complete": "log-wrong";
 
                 $('#next > button').prop('disabled', true);
                 $('#prev > button').prop('disabled', true);
                 $("#next").css("display", 'none');
                 $("#prev").css("display", 'none');
             } else {
-                paragraph.innerHTML = result.commandType ? "Instance found. " + command + " is consistent." : "Counter-example found. " + command + " is inconsistent.";
-                paragraph.className = result.commandType ? "log-complete" : "log-wrong";
+                paragraph.innerHTML = result.check ? "Counter-example found. " + command + " is inconsistent." : "Instance found. " + command + " is consistent.";
+                paragraph.className = result.check ? "log-wrong" : "log-complete";
                 initGraphViewer('instance');
                 updateGraph(result);
 

--- a/meteor/client/templates/alloyEditor/downloadTree.js
+++ b/meteor/client/templates/alloyEditor/downloadTree.js
@@ -3,6 +3,8 @@ import {
 } from "../../lib/editor/feedback"
 
 function processTree() {
+    if ($("#downloadTree > button").is(":disabled")) return
+
     let linkId = Router.current().params._id
     Meteor.call("downloadTree", linkId, (err, res) => {
         if (err) return displayError(err)

--- a/meteor/lib/collections/model.js
+++ b/meteor/lib/collections/model.js
@@ -49,7 +49,7 @@ Model.attachSchema(new SimpleSchema({
      * execution.
      */
     sat: { 
-        type: Boolean,
+        type: Number,
         optional: true
     },
     /** the timestamp. */

--- a/meteor/lib/collections/model.js
+++ b/meteor/lib/collections/model.js
@@ -40,8 +40,24 @@ Model.attachSchema(new SimpleSchema({
      * optional field for the index of the executed command, if created by
      * execution.
      */
-    command: {
+    cmd_i: {
         type: Number,
+        optional: true
+    },
+    /**
+     * optional field for the name of the executed command, if created by
+     * execution.
+     */
+    cmd_n: {
+        type: String,
+        optional: true
+    },
+    /**
+     * optional field, whether the command was a check (1) or a run (0), if
+     * created by execution.
+     */
+    cmd_c: {
+        type: Boolean,
         optional: true
     },
     /**

--- a/meteor/lib/collections/model.js
+++ b/meteor/lib/collections/model.js
@@ -45,11 +45,18 @@ Model.attachSchema(new SimpleSchema({
         optional: true
     },
     /**
-     * optional field, whether the command was satisfiable, if created by
-     * execution.
+     * optional field, whether the command was satisfiable (1) or unsatisfiable 
+     * (0), if created by execution. if execution fails, then -1.
      */
     sat: { 
         type: Number,
+        optional: true
+    },
+    /**
+     * optional field, a possible error or warning message.
+     */
+    msg: { 
+        type: String,
         optional: true
     },
     /** the timestamp. */

--- a/meteor/server/methods/genURL.js
+++ b/meteor/server/methods/genURL.js
@@ -24,8 +24,8 @@ Meteor.methods({
     genURL: function(code, currentModelId) {
         // a new model is always created, regardless of having secrets or not
         let model = {
-            code: code,
             time: new Date().toLocaleString(),
+            code: code,
             derivationOf: currentModelId
         }
 

--- a/meteor/server/methods/getInstances.js
+++ b/meteor/server/methods/getInstances.js
@@ -12,14 +12,12 @@ Meteor.methods({
       * 
       * @param {String} code the Alloy model to execute
       * @param {Number} commandIndex the index of the command to execute
-      * @param {Boolean} commandType whether the command was a run (true) or
-      *     check (false)
       * @param {String} currentModelId the id of the current model (from which
       *     the new will derive)
       * 
       * @returns the instance data and the id of the new saved model
       */
-    getInstances: function(code, commandIndex, commandType, currentModelId) {
+    getInstances: function(code, commandIndex, currentModelId) {
         return new Promise((resolve, reject) => {
             // if no secrets, try to extract from original
             let code_with_secrets = code
@@ -58,9 +56,6 @@ Meteor.methods({
                 } else {
                     // if unsat, still list with single element
                     sat = content[0].unsat?0:1;
-                    Object.keys(content).forEach(k => {
-                        content[k].commandType = commandType;
-                    });
                 }
                 let original
                 // if the model has secrets and the previous hadn't, then it is a new root

--- a/meteor/server/methods/getInstances.js
+++ b/meteor/server/methods/getInstances.js
@@ -57,9 +57,9 @@ Meteor.methods({
                     sat = -1;
                 } else {
                     // if unsat, still list with single element
+                    sat = content[0].unsat?0:1;
                     Object.keys(content).forEach(k => {
                         content[k].commandType = commandType;
-                        sat = content[k].unsat?0:1;
                     });
                 }
                 let original

--- a/meteor/server/methods/getInstances.js
+++ b/meteor/server/methods/getInstances.js
@@ -17,11 +17,11 @@ Meteor.methods({
       * 
       * @returns the instance data and the id of the new saved model
       */
-    getInstances: function(code, commandIndex, currentModelId) {
+    getInstances: function(code, commandIndex, fromPrivate, currentModelId) {
         return new Promise((resolve, reject) => {
             // if no secrets, try to extract from original
             let code_with_secrets = code
-            if (currentModelId && !containsValidSecret(code)) {
+            if (currentModelId && !containsValidSecret(code) && !fromPrivate) {
                 let o = Model.findOne(currentModelId).original
                 code_with_secrets = code + extractSecrets(Model.findOne(o).code).secret                    
             }

--- a/meteor/server/methods/getInstances.js
+++ b/meteor/server/methods/getInstances.js
@@ -52,13 +52,16 @@ Meteor.methods({
                 if (error) reject(error)
 
                 let content = JSON.parse(result.content);
-                // if unsat, still list with single element
                 let sat
-                Object.keys(content).forEach(k => {
-                    content[k].commandType = commandType;
-                    sat = content[k].unsat;
-                });
-
+                if (content.alloy_error) {
+                    sat = -1;
+                } else {
+                    // if unsat, still list with single element
+                    Object.keys(content).forEach(k => {
+                        content[k].commandType = commandType;
+                        sat = content[k].unsat?0:1;
+                    });
+                }
                 let original
                 // if the model has secrets and the previous hadn't, then it is a new root
                 if (!currentModelId || (containsValidSecret(code) && !containsValidSecret(Model.findOne(currentModelId).code))) {

--- a/meteor/server/methods/getInstances.js
+++ b/meteor/server/methods/getInstances.js
@@ -52,10 +52,12 @@ Meteor.methods({
                 let content = JSON.parse(result.content);
                 let sat
                 if (content.alloy_error) {
+                    msg = content.msg
                     sat = -1;
                 } else {
                     // if unsat, still list with single element
                     sat = content[0].unsat?0:1;
+                    msg = content[0].msg
                 }
                 let original
                 // if the model has secrets and the previous hadn't, then it is a new root
@@ -68,7 +70,7 @@ Meteor.methods({
                 }
 
                 // update the root
-                Model.update({ _id : new_model_id },{$set: {original : original, sat : sat}})
+                Model.update({ _id : new_model_id },{$set: {original : original, sat : sat, msg : msg}})
 
                 // resolve the promise
                 resolve({

--- a/meteor/server/methods/getInstances.js
+++ b/meteor/server/methods/getInstances.js
@@ -28,10 +28,10 @@ Meteor.methods({
 
             // save executed model to database
             let new_model = {
+                time: new Date().toLocaleString(),
                 // original code, without secrets
                 code: code,
-                command: commandIndex,
-                time: new Date().toLocaleString(),
+                cmd_i: commandIndex,
                 derivationOf: currentModelId,
             }
 
@@ -51,6 +51,8 @@ Meteor.methods({
 
                 let content = JSON.parse(result.content);
                 let sat
+                let cmd_n
+                let chk
                 if (content.alloy_error) {
                     msg = content.msg
                     sat = -1;
@@ -58,6 +60,8 @@ Meteor.methods({
                     // if unsat, still list with single element
                     sat = content[0].unsat?0:1;
                     msg = content[0].msg
+                    cmd_n = content[0].cmd_n
+                    chk = content[0].check
                 }
                 let original
                 // if the model has secrets and the previous hadn't, then it is a new root
@@ -70,7 +74,7 @@ Meteor.methods({
                 }
 
                 // update the root
-                Model.update({ _id : new_model_id },{$set: {original : original, sat : sat, msg : msg}})
+                Model.update({ _id : new_model_id },{$set: {original : original, sat : sat, cmd_n: cmd_n, cmd_c : chk, msg : msg}})
 
                 // resolve the promise
                 resolve({

--- a/meteor/server/methods/getProjection.js
+++ b/meteor/server/methods/getProjection.js
@@ -24,10 +24,10 @@ Meteor.methods({
                 if (error) reject(error)
                 let content = JSON.parse(result.content)
                 if (content.unsat) {
-                    content.commandType = "check";
+                    content.check = true;
                 } else {
                     Object.keys(content).forEach(k => {
-                        content[k].commandType = "check";
+                        content[k].check = true;
                     });
                 }
                 resolve(content);

--- a/meteor/server/methods/nextInstances.js
+++ b/meteor/server/methods/nextInstances.js
@@ -10,14 +10,12 @@ Meteor.methods({
       * the database.
       * 
       * @param {Number} commandIndex the index of the command to execute
-      * @param {Boolean} commandType whether the command was a run (true) or
-      *     check (false)
       * @param {String} currentModelId the id of the current model (from which
       *     the new will derive)
       * 
       * @returns the instance data and the id of the new saved model
       */
-    nextInstances: function(code, commandIndex, commandType, currentModelId) {
+    nextInstances: function(code, commandIndex, currentModelId) {
         return new Promise((resolve, reject) => {
             // must send model in case session has expired and must be restarted
             // if no secrets, try to extract from original
@@ -39,13 +37,7 @@ Meteor.methods({
                 if (error) reject(error)
 
                 let content = JSON.parse(result.content);
-                // if unsat, still list with single element
-                let sat
-                Object.keys(content).forEach(k => {
-                    content[k].commandType = commandType;
-                    sat = content[k].unsat;
-                });
-
+               
                 // resolve the promise
                 resolve({
                     instances: content,

--- a/meteor/server/methods/shareInstance.js
+++ b/meteor/server/methods/shareInstance.js
@@ -16,7 +16,7 @@ Meteor.methods({
     storeInstance: function(modelId, command, instance, themeData) {
         return Instance.insert({
             model_id: modelId,
-            command: command,
+            cmd_i: command,
             graph: instance,
             theme: themeData,
             time: new Date().toLocaleString()


### PR DESCRIPTION
- store whether the an error was found during execution (close #48)
- store error or warning messages thrown during execution
- store additional information about executed command (type and label, other than index)
- fixed a bug where sat flags were incorrectly stored when less instances than threshold (close #49)
- fixed a bug where syntax error messages were not shown in the client (close #47)
- disabled download tree really disabled (close #51)
- fixed a bug where secrets where being retrieved after deletion (close #52)
- command type now determined by Alloy API rather than inferred by client