### PR TITLE
Fixes on instance sharing and viz settings (v1.2.5) 

### DIFF
--- a/meteor/client/lib/visualizer/atomSettingsManagement.js
+++ b/meteor/client/lib/visualizer/atomSettingsManagement.js
@@ -1,5 +1,5 @@
 atomSettings = {};
-atomSettings.nodeColors = [{ type: "univ", color: "#68DB53" }];
+atomSettings.nodeColors = [{ type: "univ", color: "#2ECC40" }];
 atomSettings.nodeShapes = [{ type: "univ", shape: "ellipse" }];
 atomSettings.nodeBorders = [{ type: "univ", border: "solid" }];
 atomSettings.unconnectedNodes = [{ type: "univ", unconnectedNodes: "false" }];

--- a/meteor/client/lib/visualizer/graphManipulationImpl.js
+++ b/meteor/client/lib/visualizer/graphManipulationImpl.js
@@ -387,7 +387,7 @@ initGraphViewer = function (element) {
         return false;
     });
 
-        //right click event on cytoscape's node
+    //right click event on cytoscape's node
     cy.on('cxttap', 'edge', {}, function (evt) {
         //Place right click options menu on mouse position and display it
         $('#optionsMenu').css({

--- a/meteor/client/lib/visualizer/graphManipulationImpl.js
+++ b/meteor/client/lib/visualizer/graphManipulationImpl.js
@@ -422,6 +422,7 @@ initGraphViewer = function (element) {
     });
 
     cy.on('render', function (event) {
+        $("#url-instance-permalink").empty()
         $("#genInstanceUrl > button").prop('disabled', false);
     });
 

--- a/meteor/client/lib/visualizer/graphManipulationImpl.js
+++ b/meteor/client/lib/visualizer/graphManipulationImpl.js
@@ -1,8 +1,6 @@
 import cytoscape from 'cytoscape';
 
 updateGraph = function (instance) {    
-    //If not yet initialized, create new cytoscape object using the text area identified by 'instance' class.
-    if (!cy) initGraphViewer("instance");
     $('#instanceViewer').show();
     $('#genInstanceUrl').show();
     // Remove previous nodes and edges.

--- a/meteor/client/lib/visualizer/graphManipulationImpl.js
+++ b/meteor/client/lib/visualizer/graphManipulationImpl.js
@@ -379,8 +379,31 @@ initGraphViewer = function (element) {
             //if the menu's width overflows page width, place it behind the cursor.
             'left': evt.originalEvent.screenX + 1 + 300 > $(window).width() ? evt.originalEvent.offsetX + 1 - 300 : evt.originalEvent.offsetX + 1
         }).fadeIn('slow');
-        Session.set("rightClickTarget", undefined);
-        Session.set("rightClickTarget", evt.cyTarget.data().type);
+        $("#changeAtomShape").show();
+        $("#rightClickProject").show();
+        Session.set("rightClickRelation", undefined);
+        Session.set("rightClickType", evt.cyTarget.data().type);
+        updateRightClickContent();
+        return false;
+    });
+
+        //right click event on cytoscape's node
+    cy.on('cxttap', 'edge', {}, function (evt) {
+        //Place right click options menu on mouse position and display it
+        $('#optionsMenu').css({
+            // overlap cytoscape canvas
+            'z-index': 10,
+            'position': 'absolute',
+            //+1 avoids recapturing right click event and opening browser's context menu.
+            'top': evt.originalEvent.offsetY + 1,
+            //if the menu's width overflows page width, place it behind the cursor.
+            'left': evt.originalEvent.screenX + 1 + 300 > $(window).width() ? evt.originalEvent.offsetX + 1 - 300 : evt.originalEvent.offsetX + 1
+        }).fadeIn('slow');
+        $("#changeAtomShape").hide();
+        $("#rightClickProject").hide();
+        Session.set("rightClickType", undefined);
+        Session.set("rightClickRelation", evt.cyTarget.data().relation);
+        updateRightClickContent();
         return false;
     });
 

--- a/meteor/client/lib/visualizer/hierarchyImpl.js
+++ b/meteor/client/lib/visualizer/hierarchyImpl.js
@@ -70,7 +70,7 @@ updateElementSelectionContent = function () {
     });
     // Replace tag on the bottom right corner of type selection div
     $('.wrapper-select-atom > div > div.selectize-input > p').remove();
-    $('.wrapper-select-atom > div > div.selectize-input').append("<p class='select-label'>Types</p>");
+    $('.wrapper-select-atom > div > div.selectize-input').append("<p class='select-label'>Signatures</p>");
 
 
     // Add new Subsets

--- a/meteor/client/lib/visualizer/projection.js
+++ b/meteor/client/lib/visualizer/projection.js
@@ -97,10 +97,10 @@ addTypeToProjection = function(newType) {
             currentFramePosition[newType] = 0;
     } else throw `${newType} already being projected.`;
     if (atoms >= 1)
-        $('#nextFrame').addClass('enabled');
+        $('#nextFrame').prop('disabled',false);
     else
-        $('#nextFrame').removeClass('enabled');
-    $('#previousFrame').removeClass('enabled');
+        $('#nextFrame').prop('disabled',true);
+    $('#previousFrame').prop('disabled',true);
     $('.current-frame').html(currentFramePositionToString());
     $('.framePickerTarget').val(newType);
     project();
@@ -137,10 +137,10 @@ newInstanceSetup = function() {
         project();
         const atoms = lastFrame($('.framePickerTarget')[0].value);
         if (atoms >= 1) 
-            $('#nextFrame').addClass('enabled');
+            $('#nextFrame').prop('disabled',false);
         else 
-            $('#nextFrame').removeClass('enabled');
-        $('#previousFrame').removeClass('enabled');
+            $('#nextFrame').prop('disabled',true);
+        $('#previousFrame').prop('disabled',true);
         $('.frame-navigation > select').prop('disabled',false);
     } else {
         $(".frame-navigation").hide();
@@ -150,14 +150,12 @@ newInstanceSetup = function() {
 // updates the frame navigator according to a static instance (i.e., 
 // everything disabled)
 staticProjection = function() {
-    console.log(currentlyProjectedTypes)
-    console.log(currentFramePosition)
     $('.frame-navigation > select').append($('<option></option>')
         .attr('value', currentlyProjectedTypes[0])
         .text(currentlyProjectedTypes[0]));
     $('.current-frame').html(currentFramePositionToString());
-    $('#nextFrame').removeClass('enabled');
-    $('#previousFrame').removeClass('enabled');
+    $('#nextFrame').prop('disabled',true);
+    $('#previousFrame').prop('disabled',true);
     $('.frame-navigation').show();
     $('.frame-navigation > select').prop('disabled',true);
 };

--- a/meteor/client/lib/visualizer/projection.js
+++ b/meteor/client/lib/visualizer/projection.js
@@ -141,9 +141,25 @@ newInstanceSetup = function() {
         else 
             $('#nextFrame').removeClass('enabled');
         $('#previousFrame').removeClass('enabled');
+        $('.frame-navigation > select').prop('disabled',false);
     } else {
         $(".frame-navigation").hide();
     }
+};
+
+// updates the frame navigator according to a static instance (i.e., 
+// everything disabled)
+staticProjection = function() {
+    console.log(currentlyProjectedTypes)
+    console.log(currentFramePosition)
+    $('.frame-navigation > select').append($('<option></option>')
+        .attr('value', currentlyProjectedTypes[0])
+        .text(currentlyProjectedTypes[0]));
+    $('.current-frame').html(currentFramePositionToString());
+    $('#nextFrame').removeClass('enabled');
+    $('#previousFrame').removeClass('enabled');
+    $('.frame-navigation').show();
+    $('.frame-navigation > select').prop('disabled',true);
 };
 
 // saves current node positions

--- a/meteor/client/lib/visualizer/relationSettingsManagement.js
+++ b/meteor/client/lib/visualizer/relationSettingsManagement.js
@@ -7,12 +7,12 @@ getRelationColor = function (relationType) {
                 return relationSettings.nodeColors[i].color;
             }
         }
-        relationSettings.nodeColors.push({ type: relationType, color: '#9988CC' });
-        return '#9988CC';
+        relationSettings.nodeColors.push({ type: relationType, color: '#0074D9' });
+        return '#0074D9';
     }
     relationSettings.nodeColors = [];
-    relationSettings.nodeColors.push({ type: relationType, color: '#9988CC' });
-    return '#9988CC';
+    relationSettings.nodeColors.push({ type: relationType, color: '#0074D9' });
+    return '#0074D9';
 };
 
 getRelationLabel = function (relationType) {

--- a/meteor/client/stylesheets/alloy4fun.css
+++ b/meteor/client/stylesheets/alloy4fun.css
@@ -267,21 +267,7 @@ body {
     margin-top:50px;
 }
 
-.colorpicker-element {
-    border-color: transparent;
-    color: #333;
-    width: 100%;
-    text-align: center;
-    background: rgba(142, 140, 140, 0.88);
-}
 
-.colorpicker-element.settings {
-    background: white !important;
-    border-radius: 4px;
-    height: 24px;
-    width: 128px;
-    text-align: left;
-}
 
 .shapePickerTarget.settings {
     background: white !important;
@@ -602,18 +588,13 @@ input[disabled] {
     padding: 10px;
 }
 
-#rightClickInheritAtomColor {
-    position: relative;
-    top: 3px;
-}
-
-.right-click-inherit-color {
-    text-align: center;
-    background-color: rgba(142, 140, 140, 0.88);
-    border-top: 1px solid grey !important;
-}
-
 .right-click-shape-picker {
+    width: 100%;
+    background-color: rgba(142, 140, 140, 0.88);
+    padding-left: 16px;
+}
+
+.right-click-color-picker {
     width: 100%;
     background-color: rgba(142, 140, 140, 0.88);
     padding-left: 16px;

--- a/meteor/client/stylesheets/alloy4fun.css
+++ b/meteor/client/stylesheets/alloy4fun.css
@@ -560,10 +560,17 @@ input[disabled] {
     width: 128px;
 }
 
+.frame-navigation {
+    position: absolute;
+    bottom: 10px;
+    left: 45%;
+    z-index: 10;
+}
+
 .framePickerTarget {
     height: 28px !important;
     position: relative;
-    top: 5px;
+    top: 10px;
 }
 
 .framePickerTarget,
@@ -578,30 +585,20 @@ input[disabled] {
 
 }
 
-.frame-navigation {
-    position: absolute;
-    bottom: 10px;
-    left: 45%;
-    z-index: 10;
-}
-
-.enabled {
-    color: #009933 !important;
-}
-
 #previousFrame {
-    padding: 10px;
-    margin-right: 10px;
+    padding-bottom: 0px;
+    margin-right: 0px;
     font-size: 16px;
 }
 
 #nextFrame {
-    padding: 10px;
-    margin-left: 10px;
+    padding: 0px;
+    margin-left: 0px;
     font-size: 16px;
 }
 
 .current-frame {
+    margin-top : 4px;
     padding: 10px;
 }
 

--- a/meteor/client/templates/alloyEditor/alloyEditor.js
+++ b/meteor/client/templates/alloyEditor/alloyEditor.js
@@ -198,7 +198,7 @@ Template.alloyEditor.onRendered(() => {
             currentlyProjectedTypes = themeData.currentlyProjectedTypes;
             if (themeData.metaPrimSigs) metaPrimSigs = themeData.metaPrimSigs;
             if (themeData.metaSubsetSigs) metaSubsetSigs = themeData.metaSubsetSigs;
-            staticProjection();
+            if (currentlyProjectedTypes.length != 0) staticProjection();
         }
 
         if (model.instance) { // if there is an instance to show
@@ -206,6 +206,7 @@ Template.alloyEditor.onRendered(() => {
                 $('#instanceViewer').show();
                 cy.add(model.instance.graph.elements);
                 updateElementSelectionContent();
+                cy.resize();
                 applyCurrentLayout();
             }
         }

--- a/meteor/client/templates/alloyEditor/alloyEditor.js
+++ b/meteor/client/templates/alloyEditor/alloyEditor.js
@@ -162,11 +162,7 @@ Template.alloyEditor.events({
 
 /* Callbacks added with this method are called once when an instance of Template.alloyEditor is rendered into DOM nodes and put into the document for the first time. */
 Template.alloyEditor.onRendered(() => {
-    try {
-        cy;
-    } catch (e) {
-        initGraphViewer('instance');
-    }
+    initGraphViewer('instance');
 
     buttonsEffects(); //Adds click effects to Buttons
     hideButtons(); //Hide Next, Previous, Run... buttons on startup
@@ -210,6 +206,7 @@ Template.alloyEditor.onRendered(() => {
                 $('#instanceViewer').show();
                 cy.add(model.instance.graph.elements);
                 updateElementSelectionContent();
+                applyCurrentLayout();
             }
         }
     } else {
@@ -275,7 +272,7 @@ function handleExecuteModel(err, result) {
                 resetPositions();
                 initGraphViewer('instance');
                 updateGraph(result);
-
+              
                 $("#next").css("display", 'initial');
                 $("#prev").css("display", 'initial');
             }

--- a/meteor/client/templates/alloyEditor/alloyEditor.js
+++ b/meteor/client/templates/alloyEditor/alloyEditor.js
@@ -206,6 +206,7 @@ Template.alloyEditor.onRendered(() => {
                 $('#instanceViewer').show();
                 cy.add(model.instance.graph.elements);
                 updateElementSelectionContent();
+                staticProjection();
             }
         }
     } else {

--- a/meteor/client/templates/alloyEditor/alloyEditor.js
+++ b/meteor/client/templates/alloyEditor/alloyEditor.js
@@ -193,8 +193,8 @@ Template.alloyEditor.onRendered(() => {
             $("#hidden_icon").css("display", 'initial');
         }
 
-        if (model.instance) { // if there is an instance to show
-            let themeData = model.instance.theme;
+        let themeData = model.theme;
+        if (themeData) {    
             atomSettings = themeData.atomSettings;
             relationSettings = themeData.relationSettings;
             generalSettings = themeData.generalSettings;
@@ -202,11 +202,14 @@ Template.alloyEditor.onRendered(() => {
             currentlyProjectedTypes = themeData.currentlyProjectedTypes;
             if (themeData.metaPrimSigs) metaPrimSigs = themeData.metaPrimSigs;
             if (themeData.metaSubsetSigs) metaSubsetSigs = themeData.metaSubsetSigs;
+            staticProjection();
+        }
+
+        if (model.instance) { // if there is an instance to show
             if (cy) { //Load graph JSON data in case of instance sharing.
                 $('#instanceViewer').show();
                 cy.add(model.instance.graph.elements);
                 updateElementSelectionContent();
-                staticProjection();
             }
         }
     } else {

--- a/meteor/client/templates/alloyEditor/alloyEditor.js
+++ b/meteor/client/templates/alloyEditor/alloyEditor.js
@@ -180,11 +180,11 @@ Template.alloyEditor.onRendered(() => {
         // save the loaded model id for later derivations
         Session.set("last_id", model.model_id); // this will change on execute
         Session.set("from_private", model.from_private); // this will not change
-        Session.set("hidden_commands", model.commands) // update the commands for public links that do not have them
+        Session.set("hidden_commands", model.sec_commands) // update the commands for public links that do not have them
         let cs = getCommandsFromCode(model.code)
-        if (model.commands) cs.concat(model.commands)
+        if (model.sec_commands) cs.concat(model.sec_commands)
         Session.set("commands", cs) // update the commands to start correct
-      
+
         textEditor.setValue(model.code); // update the textEditor
 
         if(model.from_private) {

--- a/meteor/client/templates/alloyEditor/genUrl.js
+++ b/meteor/client/templates/alloyEditor/genUrl.js
@@ -18,8 +18,18 @@ export {
 function clickGenUrl() {
     if ($("#genUrl > button").is(":disabled")) return
 
+    const themeData = {
+        atomSettings,
+        relationSettings,
+        generalSettings,
+        currentFramePosition,
+        currentlyProjectedTypes,
+        metaPrimSigs,
+        metaSubsetSigs,
+    };
+
     let modelToShare = textEditor.getValue();
-    Meteor.call('genURL', modelToShare, Session.get("last_id"), handleGenURLEvent);
+    Meteor.call('genURL', modelToShare, Session.get("last_id"), themeData, handleGenURLEvent);
 }
 
 /* genUrlbtn event handler after genUrl method */

--- a/meteor/client/templates/visSettings/atomSettings/atomSettings.html
+++ b/meteor/client/templates/visSettings/atomSettings/atomSettings.html
@@ -94,6 +94,5 @@
                 </div>
             </div>
         </div>
-        {{updateContent}}
     </div>
 </template>

--- a/meteor/client/templates/visSettings/atomSettings/atomSettings.html
+++ b/meteor/client/templates/visSettings/atomSettings/atomSettings.html
@@ -1,6 +1,6 @@
 <template name="atomSettings">
     <div class="atom-settings">
-        <h3 class="settings-info">Type Settings</h3>
+        <h3 class="settings-info">Signature Settings</h3>
         {{#with getType}}<h5 class="settings-info">Sig {{this}}</h5>{{/with}}
         <hr/>
         <div class="slide">

--- a/meteor/client/templates/visSettings/atomSettings/atomSettings.html
+++ b/meteor/client/templates/visSettings/atomSettings/atomSettings.html
@@ -44,11 +44,26 @@
 
                 <div class="col-md-12 option-field">
                     <label class="settings-info">Node color:</label><br/>
-                    <input id="atomColorSettings" type="text" class="settings" value="#ff3300" />
-                    <div class="not-for-univ">
-                        <label class="settings-info">Inherit color:</label>
-                        <input id= "inheritAtomColor" type="checkbox" class="checkbox-primary" >
-                    </div>
+                    <select id="atomColorSettings" class="settings">
+                        {{#if notUniv}}<option value="inherit">Inherit</option>{{/if}}
+                        <option value="#001f3f">Navy</option>
+                        <option value="#0074D9">Blue</option>
+                        <option value="#7FDBFF">Aqua</option>
+                        <option value="#39CCCC">Teal</option>
+                        <option value="#3D9970">Olive</option>
+                        <option value="#2ECC40">Green</option>
+                        <option value="#01FF70">Lime</option>
+                        <option value="#FFDC00">Yellow</option>
+                        <option value="#FF851B">Orange</option>
+                        <option value="#FF4136">Red</option>
+                        <option value="#85144b">Maroon</option>
+                        <option value="#F012BE">Fuchsia</option>
+                        <option value="#B10DC9">Purple</option>
+                        <option value="#111111">Black</option>
+                        <option value="#AAAAAA">Gray</option>
+                        <option value="#DDDDDD">Silver</option>
+                        <option value="#FFFFFF">White</option>
+                    </select>
                 </div>
                 <div class="col-md-12 option-field">
                     <label class="settings-info">Node shape:</label><br/>

--- a/meteor/client/templates/visSettings/atomSettings/atomSettings.js
+++ b/meteor/client/templates/visSettings/atomSettings/atomSettings.js
@@ -55,18 +55,8 @@ Template.atomSettings.helpers({
                     $('#hideNodes').prop('disabled', false);
                 }
             }
-            const atomColor = getAtomColor(selectedType);
-            if (atomColor == 'inherit') {
-                const color = isSubset ? '#68DB53' : getInheritedAtomColor(selectedType);
-                $('#atomColorSettings').prop('disabled', true);
-                $('#inheritAtomColor').prop('checked', true);
-                $('#atomColorSettings').colorpicker('setValue', color);
-            } else {
-                $('#atomColorSettings').prop('disabled', false);
-                $('#inheritAtomColor').prop('checked', false);
-                $('#atomColorSettings').colorpicker('setValue', atomColor);
-            }
-
+            console.log(getAtomColor(selectedType))
+            $('#atomColorSettings').val(getAtomColor(selectedType));
             $('#atomShapeSettings').val(getAtomShape(selectedType));
             $('#atomBorderSettings').val(getAtomBorder(selectedType));
         }
@@ -83,14 +73,11 @@ Template.atomSettings.events({
         refreshAttributes();
     },
 
-    'changeColor.colorpicker #atomColorSettings'(event) {
+    'change #atomColorSettings'(event) {
         const selectedType = Session.get('selectedType');
-        const color = getAtomColor(selectedType);
-        if (color != 'inherit') {
-            cy.nodes(`[type='${selectedType}']`).data({ color: event.target.value });
-            updateAtomColor(selectedType, event.target.value);
-            refreshGraph();
-        }
+        cy.nodes(`[type='${selectedType}']`).data({ color: event.target.value });
+        updateAtomColor(selectedType, event.target.value);
+        refreshGraph();
     },
 
     'change #atomShapeSettings'(event) {
@@ -122,23 +109,6 @@ Template.atomSettings.events({
             updateUnconnectedNodes(selectedType, hideUnconnectedNodes);
             $('#atomHideUnconnectedNodes').prop('checked', hideUnconnectedNodes == 'true');
         }
-    },
-    'change #inheritAtomColor'(event) {
-        const selectedType = Session.get('selectedType');
-        const isSubset = selectedType.indexOf(':') != '-1';
-        console.log(isSubset);
-        const color = isSubset ? getAtomColor(selectedType.split(':')[1]) : getInheritedAtomColor(selectedType);
-        if ($(event.target).is(':checked')) {
-            updateAtomColor(selectedType, 'inherit');
-            $('#atomColorSettings').prop('disabled', true);
-            $('#atomColorSettings').colorpicker('setValue', color);
-        } else {
-            $('#atomColorSettings').prop('disabled', false);
-            updateAtomColor(selectedType, color);
-            $('#atomColorSettings').colorpicker('setValue', color);
-        }
-
-        refreshGraph();
     },
     'change #inheritDisplayNodesNumber'(event) {
         const selectedType = Session.get('selectedType');
@@ -193,8 +163,5 @@ Template.atomSettings.events({
 
 
 Template.atomSettings.onRendered(() => {
-    $(() => {
-        $('#atomColorSettings').colorpicker({ format: 'hex' });
-    });
     $('.atom-settings').hide();
 });

--- a/meteor/client/templates/visSettings/atomSettings/atomSettings.js
+++ b/meteor/client/templates/visSettings/atomSettings/atomSettings.js
@@ -7,61 +7,62 @@ Template.atomSettings.helpers({
     notUniv() {
         const type = Session.get('selectedType');
         return (type && type != 'univ');
-    },
-    updateContent() {
-        const selectedType = Session.get('selectedType');
-        if (selectedType && selectedType == 'univ')$('.not-for-univ').hide();
-        else $('.not-for-univ').show();
-        const isSubset = selectedType ? selectedType.indexOf(':') != -1 : false;
-        if (selectedType) {
-            $('#atomLabelSettings').val(getAtomLabel(selectedType));
+    }
 
-            if (!isSubset) {
-                $('#projectOverSig').prop('checked', $.inArray(selectedType, currentlyProjectedTypes) > -1);
-                const unconnectedNodes = getUnconnectedNodesValue(selectedType);
-
-                if (unconnectedNodes == 'inherit') {
-                    $('#atomHideUnconnectedNodes').prop('disabled', true);
-                    $('#inheritHideUnconnectedNodes').prop('checked', true);
-                    $('#atomHideUnconnectedNodes').prop('checked', getInheritedHideUnconnectedNodesValue(selectedType) == 'true');
-                } else {
-                    $('#atomHideUnconnectedNodes').prop('disabled', false);
-                    $('#inheritHideUnconnectedNodes').prop('checked', false);
-                    $('#atomHideUnconnectedNodes').prop('checked', unconnectedNodes == 'true');
-                }
-
-                const displayNodesNumber = getDisplayNodesNumberValue(selectedType);
-
-                if (displayNodesNumber == 'inherit') {
-                    $('#displayNodesNumber').prop('disabled', true);
-                    $('#inheritDisplayNodesNumber').prop('checked', true);
-                    $('#displayNodesNumber').prop('checked', getInheritedDisplayNodesNumberValue(selectedType) == 'true');
-                } else {
-                    $('#displayNodesNumber').prop('disabled', false);
-                    $('#inheritDisplayNodesNumber').prop('checked', false);
-                    $('#displayNodesNumber').prop('checked', displayNodesNumber == 'true');
-                }
-
-                const visibility = getAtomVisibility(selectedType);
-
-                if (visibility == 'inherit') {
-                    const inheritedVisibility = getInheritedAtomVisibility(selectedType);
-                    $('#inheritHideNodes').prop('checked', true);
-                    $('#hideNodes').prop('checked', inheritedVisibility == 'visible');
-                    $('#hideNodes').prop('disabled', true);
-                } else {
-                    $('#inheritHideNodes').prop('checked', false);
-                    $('#hideNodes').prop('checked', visibility == 'invisible');
-                    $('#hideNodes').prop('disabled', false);
-                }
-            }
-            $('#atomColorSettings').val(getAtomColor(selectedType));
-            $('#atomShapeSettings').val(getAtomShape(selectedType));
-            $('#atomBorderSettings').val(getAtomBorder(selectedType));
-        }
-    },
 });
 
+updateOptionContentTypes = function() {
+    const selectedType = Session.get('selectedType');
+    if (selectedType && selectedType == 'univ')$('.not-for-univ').hide();
+    else $('.not-for-univ').show();
+    const isSubset = selectedType ? selectedType.indexOf(':') != -1 : false;
+    if (selectedType) {
+        $('#atomLabelSettings').val(getAtomLabel(selectedType));
+
+        if (!isSubset) {
+            $('#projectOverSig').prop('checked', $.inArray(selectedType, currentlyProjectedTypes) > -1);
+            const unconnectedNodes = getUnconnectedNodesValue(selectedType);
+
+            if (unconnectedNodes == 'inherit') {
+                $('#atomHideUnconnectedNodes').prop('disabled', true);
+                $('#inheritHideUnconnectedNodes').prop('checked', true);
+                $('#atomHideUnconnectedNodes').prop('checked', getInheritedHideUnconnectedNodesValue(selectedType) == 'true');
+            } else {
+                $('#atomHideUnconnectedNodes').prop('disabled', false);
+                $('#inheritHideUnconnectedNodes').prop('checked', false);
+                $('#atomHideUnconnectedNodes').prop('checked', unconnectedNodes == 'true');
+            }
+
+            const displayNodesNumber = getDisplayNodesNumberValue(selectedType);
+
+            if (displayNodesNumber == 'inherit') {
+                $('#displayNodesNumber').prop('disabled', true);
+                $('#inheritDisplayNodesNumber').prop('checked', true);
+                $('#displayNodesNumber').prop('checked', getInheritedDisplayNodesNumberValue(selectedType) == 'true');
+            } else {
+                $('#displayNodesNumber').prop('disabled', false);
+                $('#inheritDisplayNodesNumber').prop('checked', false);
+                $('#displayNodesNumber').prop('checked', displayNodesNumber == 'true');
+            }
+
+            const visibility = getAtomVisibility(selectedType);
+
+            if (visibility == 'inherit') {
+                const inheritedVisibility = getInheritedAtomVisibility(selectedType);
+                $('#inheritHideNodes').prop('checked', true);
+                $('#hideNodes').prop('checked', inheritedVisibility == 'visible');
+                $('#hideNodes').prop('disabled', true);
+            } else {
+                $('#inheritHideNodes').prop('checked', false);
+                $('#hideNodes').prop('checked', visibility == 'invisible');
+                $('#hideNodes').prop('disabled', false);
+            }
+        }
+        $('#atomColorSettings').val(getAtomColor(selectedType));
+        $('#atomShapeSettings').val(getAtomShape(selectedType));
+        $('#atomBorderSettings').val(getAtomBorder(selectedType));
+    }
+}
 
 Template.atomSettings.events({
     'change #atomLabelSettings'(event) {

--- a/meteor/client/templates/visSettings/atomSettings/atomSettings.js
+++ b/meteor/client/templates/visSettings/atomSettings/atomSettings.js
@@ -55,7 +55,6 @@ Template.atomSettings.helpers({
                     $('#hideNodes').prop('disabled', false);
                 }
             }
-            console.log(getAtomColor(selectedType))
             $('#atomColorSettings').val(getAtomColor(selectedType));
             $('#atomShapeSettings').val(getAtomShape(selectedType));
             $('#atomBorderSettings').val(getAtomBorder(selectedType));

--- a/meteor/client/templates/visSettings/atomSettings/atomSettings.js
+++ b/meteor/client/templates/visSettings/atomSettings/atomSettings.js
@@ -1,4 +1,3 @@
-
 Template.atomSettings.helpers({
     getType() {
         const type = Session.get('selectedType');
@@ -11,6 +10,8 @@ Template.atomSettings.helpers({
 
 });
 
+// updates the content of the signatures pane in the settings sidebar, including the
+// current state of each property
 updateOptionContentTypes = function() {
     const selectedType = Session.get('selectedType');
     if (selectedType && selectedType == 'univ')$('.not-for-univ').hide();
@@ -160,7 +161,6 @@ Template.atomSettings.events({
         }
     },
 });
-
 
 Template.atomSettings.onRendered(() => {
     $('.atom-settings').hide();

--- a/meteor/client/templates/visSettings/elementSelection/elementSelection.js
+++ b/meteor/client/templates/visSettings/elementSelection/elementSelection.js
@@ -15,7 +15,7 @@ Template.elementSelection.onRendered(() => {
         create: false,
     })[0];
 
-    $('.wrapper-select-atom > div > div.selectize-input').append("<p class='select-label'>Types</p>");
+    $('.wrapper-select-atom > div > div.selectize-input').append("<p class='select-label'>Signatures</p>");
 
     selectAtomElement.selectize.on('item_add', (value, item) => {
         item.on('click', () => {

--- a/meteor/client/templates/visSettings/elementSelection/elementSelection.js
+++ b/meteor/client/templates/visSettings/elementSelection/elementSelection.js
@@ -6,6 +6,10 @@ Template.elementSelection.events({
     'click'(event) {
         updateOptionContentTypes();
         updateOptionContentRelations();
+
+        // disable current model link since theme may change
+        $('.permalink > button').prop('disabled', false);
+        $('#url-permalink').empty()
     }
 });
 

--- a/meteor/client/templates/visSettings/elementSelection/elementSelection.js
+++ b/meteor/client/templates/visSettings/elementSelection/elementSelection.js
@@ -3,9 +3,10 @@ Template.elementSelection.helpers({
 });
 
 Template.elementSelection.events({
-    'div.wrapper-select-relation > div > div.selectize-input > div.item click'(event) {
-        console.log(event.target.value);
-    },
+    'click'(event) {
+        updateOptionContentTypes();
+        updateOptionContentRelations();
+    }
 });
 
 Template.elementSelection.onRendered(() => {

--- a/meteor/client/templates/visSettings/frameNavigation/frameNavigation.html
+++ b/meteor/client/templates/visSettings/frameNavigation/frameNavigation.html
@@ -1,9 +1,13 @@
 <template name="frameNavigation">
     <div class="frame-navigation row">
-        <i id="previousFrame" class="cbutton__icon fa fa-fw fa-step-backward auto-margin"></i>
+        <button id="previousFrame" class="cbutton">
+    	    <i class="cbutton__icon fa fa-fw fa-step-backward auto-margin"></i>
+	    </button>
         <select class="framePickerTarget">
         </select>
         <p class="current-frame"></p>
-        <i id="nextFrame" class="cbutton__icon fa fa-fw fa-step-forward auto-margin"></i>
+        <button id="nextFrame" class="cbutton">
+    	    <i class="cbutton__icon fa fa-fw fa-step-forward auto-margin"></i>
+	    </button>
     </div>
 </template>

--- a/meteor/client/templates/visSettings/frameNavigation/frameNavigation.js
+++ b/meteor/client/templates/visSettings/frameNavigation/frameNavigation.js
@@ -3,37 +3,39 @@ Template.frameNavigation.helpers({
 });
 
 Template.frameNavigation.events({
-    'click #nextFrame.enabled'() {
+    'click #nextFrame'() {
+        if ($("#nextFrame > button").is(":disabled")) return
+
         const type = $('.framePickerTarget')[0].value;
         currentFramePosition[type]++;
         if (currentFramePosition[type] == lastFrame(type)) {
-            $('#nextFrame.enabled').removeClass('enabled');
+            $('#nextFrame').prop('disabled',true);
         }
-        $('#previousFrame').addClass('enabled');
+        $('#previousFrame').prop('disabled',false);
         $('.current-frame').html(currentFramePositionToString());
         savePositions();
         project();
     },
-    'click #previousFrame.enabled'() {
+    'click #previousFrame'() {
+        if ($("#previousFrame > button").is(":disabled")) return
+
         const type = $('.framePickerTarget')[0].value;
         currentFramePosition[type]--;
         if (currentFramePosition[type] == 0) {
-            $('#previousFrame.enabled').removeClass('enabled');
+            $('#previousFrame').prop('disabled',true);
         }
-        $('#nextFrame').addClass('enabled');
+        $('#nextFrame').prop('disabled',false);
         $('.current-frame').html(currentFramePositionToString());
         savePositions();
         project();
     },
     'change .framePickerTarget'(event) {
         const selectedType = event.target.value;
-        console.log(`currentFramePosition: ${currentFramePosition}`);
         const currentAtom = currentFramePosition[selectedType];
-        console.log(`currentAtom: ${currentAtom}`);
-        $('#nextFrame').addClass('enabled');
-        $('#previousFrame').addClass('enabled');
-        if (currentAtom == lastFrame(selectedType))$('#nextFrame').removeClass('enabled');
-        if (currentAtom == 0)$('#previousFrame').removeClass('enabled');
+        $('#nextFrame').prop('disabled',false);
+        $('#previousFrame').prop('disabled',false);
+        if (currentAtom == lastFrame(selectedType))$('#nextFrame').prop('disabled',true);
+        if (currentAtom == 0)$('#previousFrame').prop('disabled',true);
     },
 });
 

--- a/meteor/client/templates/visSettings/generalSettings/generalSettings.html
+++ b/meteor/client/templates/visSettings/generalSettings/generalSettings.html
@@ -1,7 +1,7 @@
 <template name="generalSettings">
     <div>
         <div class="general-settings">
-            <h3 class="settings-info">General Graph Settings</h3>
+            <h3 class="settings-info">General Settings</h3>
             <hr/>
 
             <div class="slide">

--- a/meteor/client/templates/visSettings/relationSettings/relationSettings.html
+++ b/meteor/client/templates/visSettings/relationSettings/relationSettings.html
@@ -5,7 +5,6 @@
         <hr/>
         <div>
             <div class="slide">
-                {{updateContent}}
                 <div class="settings-interface">
 
                     <div class="col-md-12 option-field">

--- a/meteor/client/templates/visSettings/relationSettings/relationSettings.html
+++ b/meteor/client/templates/visSettings/relationSettings/relationSettings.html
@@ -15,7 +15,25 @@
 
                     <div class="col-md-12 option-field">
                         <label class="settings-info">Edge color:</label><br/>
-                        <input id="relationColorSettings" type="text" class="colorPickerTarget settings"/>
+                        <select id="relationColorSettings" class="settings">
+                            <option value="#001f3f">Navy</option>
+                            <option value="#0074D9">Blue</option>
+                            <option value="#7FDBFF">Aqua</option>
+                            <option value="#39CCCC">Teal</option>
+                            <option value="#3D9970">Olive</option>
+                            <option value="#2ECC40">Green</option>
+                            <option value="#01FF70">Lime</option>
+                            <option value="#FFDC00">Yellow</option>
+                            <option value="#FF851B">Orange</option>
+                            <option value="#FF4136">Red</option>
+                            <option value="#85144b">Maroon</option>
+                            <option value="#F012BE">Fuchsia</option>
+                            <option value="#B10DC9">Purple</option>
+                            <option value="#111111">Black</option>
+                            <option value="#AAAAAA">Gray</option>
+                            <option value="#DDDDDD">Silver</option>
+                            <option value="#FFFFFF">White</option>
+                        </select>
                     </div>
 
                     <div class="col-md-12 option-field">

--- a/meteor/client/templates/visSettings/relationSettings/relationSettings.js
+++ b/meteor/client/templates/visSettings/relationSettings/relationSettings.js
@@ -5,8 +5,8 @@ Template.relationSettings.helpers({
     updateContent() {
         const selectedRelation = Session.get('selectedRelation');
         if (selectedRelation) {
+            $('#relationColorSettings').val(getRelationColor(selectedRelation));
             $('#relationLabelSettings').val(getRelationLabel(selectedRelation));
-            $('#relationColorSettings').colorpicker('setValue', getRelationColor(selectedRelation));
             $('#showAsArcs').prop('checked', isShowAsArcsOn(selectedRelation));
             $('#showAsAttributes').prop('checked', isShowAsAttributesOn(selectedRelation));
             $('#relationEdgeStyleSettings').val(getRelationEdgeStyle(selectedRelation));
@@ -23,7 +23,7 @@ Template.relationSettings.events({
         refreshAttributes();
     },
 
-    'changeColor.colorpicker #relationColorSettings'(event) {
+    'change #relationColorSettings'(event) {
         const selectedRelation = Session.get('selectedRelation');
         cy.edges(`[relation='${selectedRelation}']`).data({ color: event.target.value });
         updateRelationColor(selectedRelation, event.target.value);
@@ -47,8 +47,5 @@ Template.relationSettings.events({
 });
 
 Template.relationSettings.onRendered(() => {
-    $(() => {
-        $('#relationColorSettings').colorpicker({ format: 'hex' });
-    });
     $('.relation-settings').hide();
 });

--- a/meteor/client/templates/visSettings/relationSettings/relationSettings.js
+++ b/meteor/client/templates/visSettings/relationSettings/relationSettings.js
@@ -2,17 +2,18 @@ Template.relationSettings.helpers({
     getRelation() {
         return Session.get('selectedRelation');
     },
-    updateContent() {
-        const selectedRelation = Session.get('selectedRelation');
-        if (selectedRelation) {
-            $('#relationColorSettings').val(getRelationColor(selectedRelation));
-            $('#relationLabelSettings').val(getRelationLabel(selectedRelation));
-            $('#showAsArcs').prop('checked', isShowAsArcsOn(selectedRelation));
-            $('#showAsAttributes').prop('checked', isShowAsAttributesOn(selectedRelation));
-            $('#relationEdgeStyleSettings').val(getRelationEdgeStyle(selectedRelation));
-        }
-    },
 });
+
+updateOptionContentRelations = function () {
+    const selectedRelation = Session.get('selectedRelation');
+    if (selectedRelation) {
+        $('#relationColorSettings').val(getRelationColor(selectedRelation));
+        $('#relationLabelSettings').val(getRelationLabel(selectedRelation));
+        $('#showAsArcs').prop('checked', isShowAsArcsOn(selectedRelation));
+        $('#showAsAttributes').prop('checked', isShowAsAttributesOn(selectedRelation));
+        $('#relationEdgeStyleSettings').val(getRelationEdgeStyle(selectedRelation));
+    }
+}
 
 Template.relationSettings.events({
     'change #relationLabelSettings'(event) {

--- a/meteor/client/templates/visSettings/relationSettings/relationSettings.js
+++ b/meteor/client/templates/visSettings/relationSettings/relationSettings.js
@@ -4,6 +4,8 @@ Template.relationSettings.helpers({
     },
 });
 
+// updates the content of the relations pane in the settings sidebar, including the
+// current state of each property
 updateOptionContentRelations = function () {
     const selectedRelation = Session.get('selectedRelation');
     if (selectedRelation) {

--- a/meteor/client/templates/visSettings/rightClickOptionsMenu.html
+++ b/meteor/client/templates/visSettings/rightClickOptionsMenu.html
@@ -5,11 +5,28 @@
             <ul>
                 <li class="has-sub"><a id ="changeAtomColor" href='#'>Change color of {{getRightClickTargetType}}</a>
                     <ul>
-                        <li><input type="text" class="right-click-color-picker"  /></li>
-                        <li class="right-click-inherit-color">
-                            <label class="settings-info">Inherit color:</label>
-                            <input id= "rightClickInheritAtomColor" type="checkbox" class="checkbox-primary" >
-                        </li>
+                        <li>
+                            <select class="right-click-color-picker" >
+                                <option value="inherit">Inherit</option>
+                                <option value="#001f3f">Navy</option>
+                                <option value="#0074D9">Blue</option>
+                                <option value="#7FDBFF">Aqua</option>
+                                <option value="#39CCCC">Teal</option>
+                                <option value="#3D9970">Olive</option>
+                                <option value="#2ECC40">Green</option>
+                                <option value="#01FF70">Lime</option>
+                                <option value="#FFDC00">Yellow</option>
+                                <option value="#FF851B">Orange</option>
+                                <option value="#FF4136">Red</option>
+                                <option value="#85144b">Maroon</option>
+                                <option value="#F012BE">Fuchsia</option>
+                                <option value="#B10DC9">Purple</option>
+                                <option value="#111111">Black</option>
+                                <option value="#AAAAAA">Gray</option>
+                                <option value="#DDDDDD">Silver</option>
+                                <option value="#FFFFFF">White</option>
+                            </select>
+                        </li>                        
                     </ul>
                 </li>
                 <li class="has-sub">

--- a/meteor/client/templates/visSettings/rightClickOptionsMenu.html
+++ b/meteor/client/templates/visSettings/rightClickOptionsMenu.html
@@ -1,6 +1,5 @@
 <template name="rightClickOptionsMenu">
     <div id="optionsMenu">
-        {{updateRightClickContent}}
         <div id='cssmenu'>
             <ul>
                 <li class="has-sub"><a id ="changeAtomColor" href='#'>Change color of {{getRightClickTargetType}}</a>

--- a/meteor/client/templates/visSettings/rightClickOptionsMenu.js
+++ b/meteor/client/templates/visSettings/rightClickOptionsMenu.js
@@ -6,6 +6,8 @@ Template.rightClickOptionsMenu.helpers({
     }
 });
 
+// updates the content of the right-click menu, depending on whether edge or atom,
+// with the current state of each property
 updateRightClickContent = function() {
     selectedType = Session.get('rightClickType');
     if (selectedType) {
@@ -17,6 +19,10 @@ updateRightClickContent = function() {
             $('.right-click-color-picker').val(getRelationColor(selectedType));
         }
     }
+
+    // disable current model link since theme may change
+    $('.permalink > button').prop('disabled', false);
+    $('#url-permalink').empty()
 }
 
 Template.rightClickOptionsMenu.events({

--- a/meteor/client/templates/visSettings/rightClickOptionsMenu.js
+++ b/meteor/client/templates/visSettings/rightClickOptionsMenu.js
@@ -4,53 +4,27 @@ Template.rightClickOptionsMenu.helpers({
     },
     updateRightClickContent() {
         const selectedType = Session.get('rightClickTarget');
+        console.log(selectedType)
         if (selectedType) {
             const atomColor = getAtomColor(selectedType);
-            if (atomColor == 'inherit') {
-                const color = getInheritedAtomColor(selectedType);
-                $('.right-click-color-picker').prop('disabled', true);
-                $('#rightClickInheritAtomColor').prop('checked', true);
-                $('.right-click-color-picker').colorpicker('setValue', color);
-            } else {
-                $('.right-click-color-picker').prop('disabled', false);
-                $('#rightClickInheritAtomColor').prop('checked', false);
-                $('.right-click-color-picker').colorpicker('setValue', atomColor);
-            }
-
+            console.log(atomColor)
+            $('.right-click-color-picker').prop('disabled', false);
             $('.right-click-shape-picker').val(getAtomShape(selectedType));
         }
     },
 });
 
 Template.rightClickOptionsMenu.events({
-    'changeColor.colorpicker .right-click-color-picker'(event) {
+    'change .right-click-color-picker'(event) {
         const selectedType = Session.get('rightClickTarget');
-        const color = getAtomColor(selectedType);
-        if (color != 'inherit') {
-            cy.nodes(`[type='${selectedType}']`).data({ color: event.target.value });
-            updateAtomColor(selectedType, event.target.value);
-            refreshGraph();
-        }
+        cy.nodes(`[type='${selectedType}']`).data({ color: event.target.value });
+        updateAtomColor(selectedType, event.target.value);
+        refreshGraph();
     },
     'change .right-click-shape-picker'(event) {
         const selectedType = Session.get('rightClickTarget');
         cy.nodes(`[type='${selectedType}']`).data({ shape: event.target.value });
         updateAtomShape(selectedType, event.target.value);
-        refreshGraph();
-    },
-    'change #rightClickInheritAtomColor'(event) {
-        const selectedType = Session.get('rightClickTarget');
-        const color = getInheritedAtomColor(selectedType);
-        if ($(event.target).is(':checked')) {
-            updateAtomColor(selectedType, 'inherit');
-            $('.right-click-color-picker').prop('disabled', true);
-            $('.right-click-color-picker').colorpicker('setValue', color);
-        } else {
-            $('.right-click-color-picker').prop('disabled', false);
-            updateAtomColor(selectedType, color);
-            $('.right-click-color-picker').colorpicker('setValue', color);
-        }
-
         refreshGraph();
     },
     'click #rightClickProject'() {
@@ -70,8 +44,4 @@ Template.rightClickOptionsMenu.events({
 
 Template.rightClickOptionsMenu.onRendered(() => {
     $('#optionsMenu').hide();
-    // Initialize color picker plugin
-    $(() => {
-        $('.right-click-color-picker').colorpicker({ format: 'hex' });
-    });
 });

--- a/meteor/client/templates/visSettings/rightClickOptionsMenu.js
+++ b/meteor/client/templates/visSettings/rightClickOptionsMenu.js
@@ -1,32 +1,45 @@
 Template.rightClickOptionsMenu.helpers({
     getRightClickTargetType() {
-        return Session.get('rightClickTarget');
-    },
-    updateRightClickContent() {
-        const selectedType = Session.get('rightClickTarget');
-        if (selectedType) {
-            const atomColor = getAtomColor(selectedType);
-            $('.right-click-color-picker').prop('disabled', false);
-            $('.right-click-shape-picker').val(getAtomShape(selectedType));
-        }
-    },
+        target = Session.get('rightClickType');
+        if (!target) target = Session.get('rightClickRelation');
+        return target;
+    }
 });
+
+updateRightClickContent = function() {
+    selectedType = Session.get('rightClickType');
+    if (selectedType) {
+        $('.right-click-color-picker').val(getAtomColor(selectedType));
+        $('.right-click-shape-picker').val(getAtomShape(selectedType));
+    } else {
+        selectedType = Session.get('rightClickRelation');
+        if (selectedType) {
+            $('.right-click-color-picker').val(getRelationColor(selectedType));
+        }
+    }
+}
 
 Template.rightClickOptionsMenu.events({
     'change .right-click-color-picker'(event) {
-        const selectedType = Session.get('rightClickTarget');
-        cy.nodes(`[type='${selectedType}']`).data({ color: event.target.value });
-        updateAtomColor(selectedType, event.target.value);
+        selectedType = Session.get('rightClickType');
+        if (selectedType) {
+            cy.nodes(`[type='${selectedType}']`).data({ color: event.target.value });
+            updateAtomColor(selectedType, event.target.value);            
+        } else {
+            selectedType = Session.get('rightClickRelation');
+            cy.edges(`[relation='${selectedType}']`).data({ color: event.target.value });
+            updateRelationColor(selectedType, event.target.value);
+        }
         refreshGraph();
     },
     'change .right-click-shape-picker'(event) {
-        const selectedType = Session.get('rightClickTarget');
+        const selectedType = Session.get('rightClickType');
         cy.nodes(`[type='${selectedType}']`).data({ shape: event.target.value });
         updateAtomShape(selectedType, event.target.value);
         refreshGraph();
     },
     'click #rightClickProject'() {
-        const selectedType = Session.get('rightClickTarget');
+        const selectedType = Session.get('rightClickType');
         try {
             if (currentlyProjectedTypes.indexOf(selectedType) == -1)addTypeToProjection(selectedType);
             else removeTypeFromProjection(selectedType);

--- a/meteor/client/templates/visSettings/rightClickOptionsMenu.js
+++ b/meteor/client/templates/visSettings/rightClickOptionsMenu.js
@@ -4,10 +4,8 @@ Template.rightClickOptionsMenu.helpers({
     },
     updateRightClickContent() {
         const selectedType = Session.get('rightClickTarget');
-        console.log(selectedType)
         if (selectedType) {
             const atomColor = getAtomColor(selectedType);
-            console.log(atomColor)
             $('.right-click-color-picker').prop('disabled', false);
             $('.right-click-shape-picker').val(getAtomShape(selectedType));
         }

--- a/meteor/lib/collections/instance.js
+++ b/meteor/lib/collections/instance.js
@@ -21,11 +21,6 @@ Instance.attachSchema(new SimpleSchema({
         type: Object,
         blackbox: true
     },
-    /** the theme associated with this instance. */
-    theme: { 
-        type: Object,
-        blackbox: true
-    },
     /** the timestamp. */
     time: {
         type: String

--- a/meteor/lib/collections/model.js
+++ b/meteor/lib/collections/model.js
@@ -75,6 +75,12 @@ Model.attachSchema(new SimpleSchema({
         type: String,
         optional: true
     },
+    /** the theme associated with this model. */
+    theme: { 
+        type: Object,
+        blackbox: true,
+        optional: true
+    },
     /** the timestamp. */
     time: {
         type: String,

--- a/meteor/server/methods/genURL.js
+++ b/meteor/server/methods/genURL.js
@@ -18,15 +18,17 @@ Meteor.methods({
       * 
       * @param {String} code the Alloy model to be shared
       * @param {String} currentModelId the id of the current model
+      * @param {Object} themeData the theme information for cytoscape
       * 
       * @return The 'id' of the model link, used in Share Model option
       */
-    genURL: function(code, currentModelId) {
+    genURL: function(code, currentModelId, themeData) {
         // a new model is always created, regardless of having secrets or not
         let model = {
             time: new Date().toLocaleString(),
             code: code,
-            derivationOf: currentModelId
+            derivationOf: currentModelId,
+            theme: themeData
         }
 
         // insert new model
@@ -35,7 +37,7 @@ Meteor.methods({
         // generate the public link
         let publicLinkId = Link.insert({
             model_id: modelId,
-            private: false
+            private: false,
         });
 
         // generate the private link if secrets are present

--- a/meteor/server/methods/getInstances.js
+++ b/meteor/server/methods/getInstances.js
@@ -32,7 +32,7 @@ Meteor.methods({
                 // original code, without secrets
                 code: code,
                 cmd_i: commandIndex,
-                derivationOf: currentModelId,
+                derivationOf: currentModelId
             }
 
             // insert the new model

--- a/meteor/server/methods/getModel.js
+++ b/meteor/server/methods/getModel.js
@@ -24,10 +24,10 @@ Meteor.methods({
 })
 
 /**
-  * Receives a link id and returns the corresponding model. If a
-  * link to a model, returns the code with or without code depending on
-  * whether it is a public or private link. If public, stores the secret
-  * commands so that they are still publicly available.
+  * Receives a link id and returns the corresponding model. If a link to a
+  * model, returns the code with or without secrets depending on whether it is
+  * a public or private link. If public, stores the secret commands so that
+  * they are still publicly available.
   *
   * @param {String} linkId the potential link id
   * @return the respective model
@@ -37,14 +37,15 @@ function getModelFromLink(linkId) {
     if (!link) return //undefined if link does not exist
     let model = Model.findOne(link.model_id)
 
-    // if the link is public, retrieve the secrets from the root (original)
+    // if the link is public, hide the secrets and retrieve the secrets commands 
+    // from the root (original)
     if (!link.private) {
         let o = Model.findOne(model.original)
         let secs = extractSecrets(o.code).secret    
         model.code = extractSecrets(model.code).public                
         // register secret commands
         let seccms = getCommandsFromCode(secs)
-        if (seccms) model.commands = seccms
+        if (seccms) model.sec_commands = seccms
     }
     model.from_private = link.private // return info about the used link type
     model.model_id = model._id // this is necessary because publish is for the linkId
@@ -54,18 +55,27 @@ function getModelFromLink(linkId) {
 /**
   * Receives an instance id and returns the associated model. Does not
   * distinguish between public or private, will present model as was when
-  * shared.
+  * shared. If no secrets, will retrieve commands from original root.
   *
   * @param {String} instanceId the potential instance id
   * @return the model associated with the instance
   */
 function getModelFromInstance(instanceId) {
     let instance = Instance.findOne(instanceId)
-    if (!instance) return //undefined if instance does not exist
+    if (!instance) return; //undefined if instance does not exist
     let model = Model.findOne(instance.model_id)
+
+    if (!containsValidSecret(model.code)) {
+      let o = Model.findOne(model.original)
+      let secs = extractSecrets(o.code).secret    
+      model.code = extractSecrets(model.code).public                
+      // register secret commands
+      let seccms = getCommandsFromCode(secs)
+      if (seccms) model.sec_commands = seccms
+    }
+
     model.instance = instance // so that frontend can access the instance
     model.from_private = false // so as to load the secrets from original on execute
-    model.commands = getCommandsFromCode(model.code)
     model.model_id = model._id // this is necessary because publish is for the linkId
     return model
 }

--- a/meteor/server/methods/shareInstance.js
+++ b/meteor/server/methods/shareInstance.js
@@ -14,11 +14,12 @@ Meteor.methods({
       * @return the id of the new instance
       */
     storeInstance: function(modelId, command, instance, themeData) {
+        Model.update({ _id : modelId },{$set: {theme : themeData}})
+
         return Instance.insert({
             model_id: modelId,
             cmd_i: command,
             graph: instance,
-            theme: themeData,
             time: new Date().toLocaleString()
         });
     }


### PR DESCRIPTION
- correctly retrieve secrets in shared instances
- correctly retrieve commands in shared instances (close #69)
- fixed the visualisation of shared projected instances (static on the frame) (close #70)
- fixed zoom/pan on shared instances (close #72)
- themes are also shared with models (not only instances) (close #71)
- replaced color picker by a pre-selection of colours (close #73)
- color of edges can be changed through right-click menu
- fixed the synchronization between the viz settings side bar and the right-click menus
- cleaned up viz settings side bar nomenclature
- frame navigation style consistent with remaining elements
