### PR TITLE
bugfix/meteor_dockerfile

### DIFF
--- a/meteor/Dockerfile
+++ b/meteor/Dockerfile
@@ -1,1 +1,1 @@
-FROM jshimko/meteor-launchpad:latest
+FROM gustawdaniel/meteor-launchpad:latest


### PR DESCRIPTION
docker-compose build doesn't work now, as mentioned in the issues: https://github.com/jshimko/meteor-launchpad/issues/148 and https://github.com/jshimko/meteor-launchpad/issues/149.

I used the image from the issue https://github.com/jshimko/meteor-launchpad/issues/151 that solves the problem